### PR TITLE
Fix: Differentiate danger button style from primary

### DIFF
--- a/src/components/common/Button.test.tsx
+++ b/src/components/common/Button.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Button } from './Button';
+
+import '@testing-library/jest-dom';
+
+describe('Button', () => {
+  test('renders with default props', () => {
+    render(<Button>Click me</Button>);
+    const button = screen.getByRole('button', { name: /click me/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass('bg-red-600');
+  });
+
+  test('renders with danger variant', () => {
+    render(<Button variant="danger">Delete</Button>);
+    const button = screen.getByRole('button', { name: /delete/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass('bg-red-800');
+    expect(button).not.toHaveClass('bg-red-600');
+  });
+});

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -29,8 +29,8 @@ export const Button: React.FC<ButtonProps> = ({
       if (disabled || isLoading) baseClasses += 'bg-gray-100 cursor-not-allowed ';
       break;
     case 'danger':
-      baseClasses += 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500 ';
-      if (disabled || isLoading) baseClasses += 'bg-red-400 cursor-not-allowed ';
+      baseClasses += 'bg-red-800 text-white hover:bg-red-900 focus:ring-red-700 ';
+      if (disabled || isLoading) baseClasses += 'bg-red-500 cursor-not-allowed ';
       break;
     case 'outline':
       baseClasses += 'bg-transparent border border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-gray-500 ';


### PR DESCRIPTION
The 'danger' button variant had the same styling as the 'primary' button variant, which could be misleading for users. This commit updates the 'danger' button to use a darker shade of red, making it visually distinct and more clearly indicating a potentially destructive action.

A new test file has been added for the Button component to verify the new styling and ensure no regressions were introduced.